### PR TITLE
Removed implicit conversion: 'int64_t'>'uint64_t'

### DIFF
--- a/broadword.hpp
+++ b/broadword.hpp
@@ -169,7 +169,7 @@ namespace succinct { namespace broadword {
         if (!x) {
             return false;
         }
-        ret = bit_position(x & -int64_t(x));
+        ret = bit_position(x & static_cast<uint64_t>(-int64_t(x)));
         return true;
 #endif
     }


### PR DESCRIPTION
Compiling with Clang version 8.1.0 I get the following error
```
warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'unsigned long long'
```